### PR TITLE
catch case with duplicate image name

### DIFF
--- a/pve-ceph-orphaned-images
+++ b/pve-ceph-orphaned-images
@@ -19,7 +19,7 @@ do
 	images=$( rbd ls $pool )
 	for i in $images;
 	do
-		if [ $(grep $i /etc/pve/nodes/*/qemu-server/* /etc/pve/nodes/*/lxc/* | wc -l) -lt 1 ] 
+		if [ $(grep $pool:$i /etc/pve/nodes/*/qemu-server/* /etc/pve/nodes/*/lxc/* | wc -l) -lt 1 ] 
 		then
 			size=""
 			if [ $(rbd du $pool/$i 2>/dev/null|grep TOTAL|wc -l) -eq 1 ]


### PR DESCRIPTION
sometimes the image name is duplicated between different pools.
this especially happens on a failed storage migration.

We can avoid this by searching for:
search for pool_name:image_name in the configuration files.